### PR TITLE
Fix allocation pointer for labels

### DIFF
--- a/dissbl.c
+++ b/dissbl.c
@@ -236,7 +236,7 @@ static void Init_labels()
 
      tmp = (int)strtol(buffer, NULL, 16);
 
-     if (!(*(label_table + tmp) = malloc(str_len)-pos+1) )
+     if (!(*(label_table + tmp) = malloc(str_len-pos+1)))
             Panic("Insuficient memory");
      strcpy(*(label_table + tmp), buffer+pos);
    }


### PR DESCRIPTION
Fix memory allocation pointer for labels. This has been causing me some headaches, because it ends up corrupting memory at odd places.
Caught using valgdind and a simple test case:

==9133== Memcheck, a memory error detector
==9133== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9133== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==9133== Command: ./disasm_test
==9133== 
==9133== Invalid write of size 1
==9133==    at 0x4839DE4: strcpy (vg_replace_strmem.c:511)
==9133==    by 0x109AA9: Init_labels (dissbl.c:249)
==9133==    by 0x109F7D: Init_dissbl (dissbl.c:340)
==9133==    by 0x1095B0: ldissbl (dissbl.c:151)
==9133==    by 0x109238: main (disasm_test.c:18)
==9133==  Address 0x4ae3f0b is 1 bytes after a block of size 10 alloc'd
==9133==    at 0x483677F: malloc (vg_replace_malloc.c:307)
==9133==    by 0x109A45: Init_labels (dissbl.c:242)
==9133==    by 0x109F7D: Init_dissbl (dissbl.c:340)
==9133==    by 0x1095B0: ldissbl (dissbl.c:151)
==9133==    by 0x109238: main (disasm_test.c:18)
==9133== 
==9133== Invalid write of size 1
==9133==    at 0x4839DF6: strcpy (vg_replace_strmem.c:511)
==9133==    by 0x109AA9: Init_labels (dissbl.c:249)
==9133==    by 0x109F7D: Init_dissbl (dissbl.c:340)
==9133==    by 0x1095B0: ldissbl (dissbl.c:151)
==9133==    by 0x109238: main (disasm_test.c:18)
==9133==  Address 0x4ae3f10 is 6 bytes after a block of size 10 alloc'd
==9133==    at 0x483677F: malloc (vg_replace_malloc.c:307)
==9133==    by 0x109A45: Init_labels (dissbl.c:242)
==9133==    by 0x109F7D: Init_dissbl (dissbl.c:340)
==9133==    by 0x1095B0: ldissbl (dissbl.c:151)
==9133==    by 0x109238: main (disasm_test.c:18)
